### PR TITLE
add support of wasm section_id==12 (DataCountSection)

### DIFF
--- a/wasm/__init__.py
+++ b/wasm/__init__.py
@@ -105,6 +105,7 @@ from .wasmtypes import (
     SEC_ELEMENT,
     SEC_CODE,
     SEC_DATA,
+    SEC_DATA_COUNT,
     SEC_NAME,
     LANG_TYPE_I32,
     LANG_TYPE_I64,

--- a/wasm/modtypes.py
+++ b/wasm/modtypes.py
@@ -176,6 +176,10 @@ class DataSection(Structure):
     entries = RepeatField(DataSegment(), lambda x: x.count)
 
 
+class DataCountSection(Structure):
+    count = VarUInt32Field()
+
+
 class Naming(Structure):
     index = VarUInt32Field()
     name_len = VarUInt32Field()
@@ -235,6 +239,7 @@ class Section(Structure):
         SEC_ELEMENT: ElementSection(),
         SEC_CODE: CodeSection(),
         SEC_DATA: DataSection(),
+        SEC_DATA_COUNT: DataCountSection(),
     }, lambda x: x.id)
 
     overhang = BytesField(lambda x: max(0, (

--- a/wasm/wasmtypes.py
+++ b/wasm/wasmtypes.py
@@ -48,6 +48,7 @@ SEC_START = 8
 SEC_ELEMENT = 9
 SEC_CODE = 10
 SEC_DATA = 11
+SEC_DATA_COUNT = 12
 SEC_NAME = b'name'
 
 # Language types.


### PR DESCRIPTION
When using clang to generate wasm code, it create section(id=12) sometime,
This patch add support of it.

Without decode of ID==12, the wasmdump will crash (throw exception).